### PR TITLE
Added support for dead-letter exchanges.

### DIFF
--- a/src/RabbitBus/Configuration/ConsumeConfigurationConventionBase.cs
+++ b/src/RabbitBus/Configuration/ConsumeConfigurationConventionBase.cs
@@ -65,5 +65,10 @@ namespace RabbitBus.Configuration
 		{
 			return 0;
 		}
+
+		public string GetDeadLetterExchangeName(Type type)
+		{
+			return null;
+		}
 	}
 }

--- a/src/RabbitBus/Configuration/ConsumeConfigurationConventionBase.cs
+++ b/src/RabbitBus/Configuration/ConsumeConfigurationConventionBase.cs
@@ -70,5 +70,10 @@ namespace RabbitBus.Configuration
 		{
 			return null;
 		}
+
+		public string GetDeadLetterRoutingKey(Type type)
+		{
+			return null;
+		}
 	}
 }

--- a/src/RabbitBus/Configuration/IConsumeConfigurationContext.cs
+++ b/src/RabbitBus/Configuration/IConsumeConfigurationContext.cs
@@ -11,5 +11,7 @@ namespace RabbitBus.Configuration
 		IConsumeConfigurationContext WithDefaultRoutingKey(string routingKey);
 		IConsumeConfigurationContext WithSerializationStrategy(ISerializationStrategy serializationStrategy);
 		IConsumeConfigurationContext OnError(Action<IErrorContext> callback);
+		IConsumeConfigurationContext WithDeadLetterExchange(string exchange);
+		IConsumeConfigurationContext WithDeadLetterRoutingKey(string routingKey);
 	}
 }

--- a/src/RabbitBus/Configuration/IConsumeConfigurationConvention.cs
+++ b/src/RabbitBus/Configuration/IConsumeConfigurationConvention.cs
@@ -19,5 +19,6 @@ namespace RabbitBus.Configuration
 		Action<IErrorContext> GetErrorCallback(Type type);
 		ushort GetQualityOfService(Type type);
 		string GetDeadLetterExchangeName(Type type);
+		string GetDeadLetterRoutingKey(Type type);
 	}
 }

--- a/src/RabbitBus/Configuration/IConsumeConfigurationConvention.cs
+++ b/src/RabbitBus/Configuration/IConsumeConfigurationConvention.cs
@@ -18,5 +18,6 @@ namespace RabbitBus.Configuration
 		ISerializationStrategy GetSerializationStrategy(Type type);
 		Action<IErrorContext> GetErrorCallback(Type type);
 		ushort GetQualityOfService(Type type);
+		string GetDeadLetterExchangeName(Type type);
 	}
 }

--- a/src/RabbitBus/Configuration/IConsumeInfo.cs
+++ b/src/RabbitBus/Configuration/IConsumeInfo.cs
@@ -17,5 +17,6 @@ namespace RabbitBus.Configuration
 		ISerializationStrategy SerializationStrategy { get; set; }
 		Action<IErrorContext> ErrorCallback { get; set; }
 		ushort QualityOfService { get; set; }
+		string DeadLetterExchangeName { get; set; }
 	}
 }

--- a/src/RabbitBus/Configuration/IConsumeInfo.cs
+++ b/src/RabbitBus/Configuration/IConsumeInfo.cs
@@ -18,5 +18,6 @@ namespace RabbitBus.Configuration
 		Action<IErrorContext> ErrorCallback { get; set; }
 		ushort QualityOfService { get; set; }
 		string DeadLetterExchangeName { get; set; }
+		string DeadLetterRoutingKey { get; set; }
 	}
 }

--- a/src/RabbitBus/Configuration/Internal/AutoConfigurator.cs
+++ b/src/RabbitBus/Configuration/Internal/AutoConfigurator.cs
@@ -99,7 +99,8 @@ namespace RabbitBus.Configuration.Internal
 			                  		IsQueueAutoDelete = convention.IsAutoDeleteQueue(type),
 			                  		IsQueueDurable = convention.IsDurableQueue(type),
 			                  		QualityOfService = convention.GetQualityOfService(type),
-			                  		DeadLetterExchangeName = convention.GetDeadLetterExchangeName(type)
+			                  		DeadLetterExchangeName = convention.GetDeadLetterExchangeName(type),
+			                  		DeadLetterRoutingKey = convention.GetDeadLetterRoutingKey(type)
 			                  	};
 
 			ISerializationStrategy serializationStrategy = convention.GetSerializationStrategy(type);

--- a/src/RabbitBus/Configuration/Internal/AutoConfigurator.cs
+++ b/src/RabbitBus/Configuration/Internal/AutoConfigurator.cs
@@ -98,7 +98,8 @@ namespace RabbitBus.Configuration.Internal
 			                  		IsExchangeDurable = convention.IsDurableExchange(type),
 			                  		IsQueueAutoDelete = convention.IsAutoDeleteQueue(type),
 			                  		IsQueueDurable = convention.IsDurableQueue(type),
-			                  		QualityOfService = convention.GetQualityOfService(type)
+			                  		QualityOfService = convention.GetQualityOfService(type),
+			                  		DeadLetterExchangeName = convention.GetDeadLetterExchangeName(type)
 			                  	};
 
 			ISerializationStrategy serializationStrategy = convention.GetSerializationStrategy(type);

--- a/src/RabbitBus/Configuration/Internal/ConsumeConfigurationContext.cs
+++ b/src/RabbitBus/Configuration/Internal/ConsumeConfigurationContext.cs
@@ -69,6 +69,12 @@ namespace RabbitBus.Configuration.Internal
 			return this;
 		}
 
+		public IConsumeConfigurationContext WithDeadLetterExchange(string exchange)
+		{
+			ConsumeInfo.DeadLetterExchangeName = exchange;
+			return this;
+		}
+
 		public IConsumeInfo ConsumeInfo { get; private set; }
 	}
 }

--- a/src/RabbitBus/Configuration/Internal/ConsumeConfigurationContext.cs
+++ b/src/RabbitBus/Configuration/Internal/ConsumeConfigurationContext.cs
@@ -75,6 +75,12 @@ namespace RabbitBus.Configuration.Internal
 			return this;
 		}
 
+		public IConsumeConfigurationContext WithDeadLetterRoutingKey(string routingKey)
+		{
+			ConsumeInfo.DeadLetterRoutingKey = routingKey;
+			return this;
+		}
+
 		public IConsumeInfo ConsumeInfo { get; private set; }
 	}
 }

--- a/src/RabbitBus/Configuration/Internal/ConsumeInfo.cs
+++ b/src/RabbitBus/Configuration/Internal/ConsumeInfo.cs
@@ -26,5 +26,6 @@ namespace RabbitBus.Configuration.Internal
 		public Action<IErrorContext> ErrorCallback { get; set; }
 		public ushort QualityOfService { get; set; }
 		public string DeadLetterExchangeName { get; set; }
+		public string DeadLetterRoutingKey { get; set; }
 	}
 }

--- a/src/RabbitBus/Configuration/Internal/ConsumeInfo.cs
+++ b/src/RabbitBus/Configuration/Internal/ConsumeInfo.cs
@@ -25,5 +25,6 @@ namespace RabbitBus.Configuration.Internal
 		public ISerializationStrategy SerializationStrategy { get; set; }
 		public Action<IErrorContext> ErrorCallback { get; set; }
 		public ushort QualityOfService { get; set; }
+		public string DeadLetterExchangeName { get; set; }
 	}
 }

--- a/src/RabbitBus/Subscription.cs
+++ b/src/RabbitBus/Subscription.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
@@ -63,8 +64,15 @@ namespace RabbitBus
                                             _consumeInfo.IsExchangeDurable,
                                             _consumeInfo.IsExchangeAutoDelete, null);
                 }
+
+                var queueDeclareArgs = new Dictionary<string, string>();
+                if (!string.IsNullOrEmpty(_consumeInfo.DeadLetterExchangeName))
+                {
+                    queueDeclareArgs.Add("x-dead-letter-exchange", _consumeInfo.DeadLetterExchangeName);
+                }
                 channel.QueueDeclare(_consumeInfo.QueueName, _consumeInfo.IsQueueDurable, _consumeInfo.Exclusive,
-                                     _consumeInfo.IsQueueAutoDelete, _exchangeArguments);
+                                     _consumeInfo.IsQueueAutoDelete, queueDeclareArgs);
+
                 if (_consumeInfo.ExchangeName != string.Empty)
                 {
                     channel.QueueBind(_consumeInfo.QueueName, _consumeInfo.ExchangeName, _routingKey, _exchangeArguments);
@@ -222,7 +230,7 @@ namespace RabbitBus
             try
             {
                 Action<IErrorContext> errorCallback = _consumeInfo.ErrorCallback ?? _defaultErrorCallback;
-                errorCallback(new ErrorContext(channel, eventArgs));
+                errorCallback(new ErrorContext(channel, eventArgs, _deadLetterStrategy));
             }
             catch (Exception exception)
             {

--- a/src/RabbitBus/Subscription.cs
+++ b/src/RabbitBus/Subscription.cs
@@ -70,6 +70,10 @@ namespace RabbitBus
                 {
                     queueDeclareArgs.Add("x-dead-letter-exchange", _consumeInfo.DeadLetterExchangeName);
                 }
+                if (!string.IsNullOrEmpty(_consumeInfo.DeadLetterRoutingKey))
+                {
+                    queueDeclareArgs.Add("x-dead-letter-routing-key", _consumeInfo.DeadLetterRoutingKey);
+                }
                 channel.QueueDeclare(_consumeInfo.QueueName, _consumeInfo.IsQueueDurable, _consumeInfo.Exclusive,
                                      _consumeInfo.IsQueueAutoDelete, queueDeclareArgs);
 


### PR DESCRIPTION
Added support for declaring queues with the x-dead-letter-exchange argument
now supported by RabbitMQ (see http://www.rabbitmq.com/dlx.html). That
argument will cause the RabbitMQ server to automatically publish rejected
messages to the given exchange along with an x-death header that contains
information about when the message was dead-lettered. This feature is
intended as a more versatile alternative to the dead letter queue
functionality currently provided by RabbitBus.

The configuration and convention classes were modified to allow specifying
the name of the dead-letter exchange that should be used. The Subscription
class was modified so that it honors the new setting and declares the queue
with the x-dead-letter-exchange argument when specified. The ErrorContext
class was also modified so that it uses the configured IDeadLetterStrategy
(which should be NullDeadLetterStrategy when the dead-letter exchange is
used) as opposed to always publishing rejected messages to a queue with a
hardcoded name.
