### PR TITLE
Dispose channel after subscription thread ended

### DIFF
--- a/src/RabbitBus/Subscription.cs
+++ b/src/RabbitBus/Subscription.cs
@@ -82,7 +82,11 @@ namespace RabbitBus
 				_consumer = new QueueingBasicConsumer(channel);
 				channel.BasicQos(0, _consumeInfo.QualityOfService, false);
 				channel.BasicConsume(_consumeInfo.QueueName, _consumeInfo.IsAutoAcknowledge, _consumer);
-				_thread = new Thread(() => Subscribe(channel));
+				_thread = new Thread(() =>
+				    {
+				        Subscribe(channel);
+                        channel.Dispose();
+				    });
 				_thread.Start();
 
 				string log =


### PR DESCRIPTION
At current master there are unclosed channels after publish callback timeout exceeded: 

![rabbitbusrpctimeout](https://f.cloud.github.com/assets/1229948/874826/a80d1fc4-f893-11e2-8265-bb8755bc4dc1.png)

This patch fixes this
